### PR TITLE
Updating local to http

### DIFF
--- a/src/test/resources/config.local.properties
+++ b/src/test/resources/config.local.properties
@@ -1,1 +1,1 @@
-baseUrl=https://localhost:8080
+baseUrl=http://localhost:8080


### PR DESCRIPTION
Local host requires http instead of https. Due to that, an update is necessary.